### PR TITLE
Remove no-install-recommends from apt-get command

### DIFF
--- a/addons/adb_server/Dockerfile
+++ b/addons/adb_server/Dockerfile
@@ -27,7 +27,7 @@ RUN case "$TARGETARCH" in \
     "arm64" | "arm" | "386") \
         echo "Fetching platform-tools for $TARGETARCH from apt" && \
         apt-get update && \
-        apt-get install -y --no-install-recommends android-sdk-platform-tools && \
+        apt-get install -y android-sdk-platform-tools && \
         rm -rf /var/lib/apt/lists/* \
         ;; \
     *) \


### PR DESCRIPTION
adb package is recommended package so it won't be installed with the `--no-install-recommends` flag.

# Proposed Changes

> Remove the `--no-install-recommends` from the apt-get in the apt install architectures

## Related Issues

>  #16 

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
